### PR TITLE
feat: add template support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 config.toml
 messageIDs.json
 Porygon
+porygon
+templates/*.override.json
+.idea/

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"Porygon/config"
+	"porygon/config"
 )
 
 type apiResponse struct {

--- a/config/config.go
+++ b/config/config.go
@@ -6,12 +6,18 @@ type Config struct {
 	Database    database
 	API         api
 	Config      config
+	LevelEmoji  map[string]string `toml:"level_emoji"`
+	RewardEmoji map[string]string `toml:"reward_emoji"`
+	LureEmoji   map[string]string `toml:"lure_emoji"`
+	RocketEmoji map[string]string `toml:"rocket_emoji"`
+	EventEmoji  map[string]string `toml:"event_emoji"`
 }
 
 type config struct {
-	RefreshInterval     int
-	IncludeActiveCounts bool
-	EmbedTitle          string
+	RefreshInterval      int
+	ErrorRefreshInterval int
+	IncludeActiveCounts  bool
+	EmbedTitle           string
 }
 
 type api struct {
@@ -40,39 +46,4 @@ type coordinates struct {
 type discord struct {
 	Token      string
 	ChannelIDs []string
-	Emojis     emojistruct
-}
-
-type emojistruct struct {
-	Valor       string
-	Mystic      string
-	Instinct    string
-	Uncontested string
-	Pokestop    string
-	Normal      string
-	Glacial     string
-	Mossy       string
-	Magnetic    string
-	Rainy       string
-	Sparkly     string
-	Scanned     string
-	Hundo       string
-	Nundo       string
-	Shinies     string
-	Grunt       string
-	Leader      string
-	Giovanni    string
-	Kecleon     string
-	Showcase    string
-	Route       string
-	Level1      string
-	Level3      string
-	Level4      string
-	Level5      string
-	Mega        string
-	Elite       string
-	Items       string
-	Encounter   string
-	Stardust    string
-	MegaEnergy  string
 }

--- a/database/db.go
+++ b/database/db.go
@@ -121,12 +121,12 @@ func GetRewardStats(db *sqlx.DB) ([]TypeCountStats, error) {
 		FROM (
 			SELECT quest_reward_type AS reward_type, COUNT(*) AS count
 			FROM pokestop
-			WHERE quest_expiry > UNIX_TIMESTAMP()
+			WHERE quest_expiry > UNIX_TIMESTAMP() AND quest_reward_type IS NOT NULL
 			GROUP BY quest_reward_type
 			UNION ALL
 			SELECT alternative_quest_reward_type AS reward_type, COUNT(*) AS count
 			FROM pokestop
-			WHERE quest_expiry > UNIX_TIMESTAMP()
+			WHERE quest_expiry > UNIX_TIMESTAMP() AND alternative_quest_reward_type IS NOT NULL
 			GROUP BY alternative_quest_reward_type
 		) AS subquery
 		GROUP BY reward_type

--- a/default.toml
+++ b/default.toml
@@ -10,41 +10,40 @@ name = "golbatdbname"
 #Discord bot token
 token = ""
 #channel IDs for Discord that you want the boards posted to, array support infinite channels
-channelIDs = ["yourchannelid","moarchannelids"] 
+channelIDs = ["yourchannelid","moarchannelids"]
 
-[discord.emojis]
-#can be any unicode emojis or custom discord emojis using the full identifier eg :emoij:12345678910 or <:emoji12345678910>
-valor = "🔴"
-mystic = "🔵"
-instinct = "🌕"
-uncontested = "⚪️"
-pokestop = "🛑"
-normal = "🎣"
-glacial = "❄️"
-mossy = "🌿"
-magnetic = "🧲"
-rainy = "💧"
-sparkly = "🏅"
-scanned = "📈"
-hundo = "💯"
-nundo = "🗑️"
-shinies = "✨"
-grunt = "🥉"
-leader = "🥈"
-giovanni = "🥇"
-kecleon = "🟢"
-showcase = "🏆"
-route = "⛳️"
-level1 = "1️⃣"
-level3 = "3️⃣"
-level4 = "4️⃣"
-level5 = "5️⃣"
-mega = "📣"
-elite = "🐲"
-items = "🛒"
-encounter = "😈"
-stardust = "🌟"
-megaenergy = "⚡️"
+[level_emoji]
+"1" = "1️⃣"
+"3" = "3️⃣"
+"4" = "4️⃣"
+"5" = "5️⃣"
+"6" = "📣"
+"9" = "🐲"
+"11" = "⚫"
+"13" = "⚫"
+
+[reward_emoji]
+"2" = "🛒"
+"3" = "🌟"
+"7" = "😈"
+"12" = "⚡️"
+
+[lure_emoji]
+"501" = "🎣"
+"502" = "❄️"
+"503" = "🌿"
+"504" = "🧲"
+"505" = "💧"
+"506" = "🏅"
+
+[rocket_emoji]
+"1" = "🥉"
+"2" = "🥈"
+"3" = "🥇"
+
+[event_emoji]
+"8" = "🟢"
+"9" = "🏆"
 
 [api]
 #golbat url and port
@@ -64,6 +63,7 @@ longitude = 180
 [config]
 #refresh time in seconds that the board will query the db
 refreshInterval = 60
+errorRefreshInterval = 30
 #if set to false active counts will be removed from hundos/nundos and API calls won't be made
 includeActiveCounts = true 
 #Title of the embed

--- a/discord/constructor.go
+++ b/discord/constructor.go
@@ -48,6 +48,13 @@ func hasValues(data interface{}) bool {
 	v := reflect.ValueOf(data)
 
 	switch v.Kind() {
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			if hasValues(v.Index(i).Interface()) {
+				return true
+			}
+		}
+		return false
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			fieldValue := v.Field(i)

--- a/discord/constructor.go
+++ b/discord/constructor.go
@@ -1,117 +1,76 @@
 package discord
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
 	"github.com/dustin/go-humanize"
-
-	"Porygon/config"
-	"Porygon/pokemon"
+	"os"
+	"porygon/config"
+	"porygon/database"
+	"strconv"
+	"text/template"
 )
 
 type GatheredStats struct {
-	ScannedCount      int
-	HundoValue        string
-	NundoValue        string
-	ShinyCount        int
-	ShinySpeciesCount int
+	Pokemon database.PokeStats
+	RaidEgg []database.RaidStats
+	Gym     database.GymStats
+	Reward  []database.TypeCountStats
+	Lure    []database.TypeCountStats
+	Rocket  []database.TypeCountStats
+	Event   []database.TypeCountStats
 
-	RaidEggStats  string
-	GymStats      string
-	PokestopStats string
-	RewardStats   string
-	LureStats     string
-	RocketStats   string
-
-	KecleonStats      string
-	ShowcaseStats     string
-	ActiveRoutesStats string
+	Pokestop int
+	Route    int
 
 	HundoActiveCount int
 	NundoActiveCount int
 }
 
-func GenerateFields(config config.Config, gathered GatheredStats) []*discordgo.MessageEmbedField {
-	fields := []*discordgo.MessageEmbedField{
-		{
-			Name:   pokemon.FormatEmoji(config.Discord.Emojis.Scanned) + " Scanned",
-			Value:  humanize.Comma(int64(gathered.ScannedCount)),
-			Inline: false,
-		},
-		{
-			Name:   pokemon.FormatEmoji(config.Discord.Emojis.Hundo) + " Hundos",
-			Value:  gathered.HundoValue,
-			Inline: false,
-		},
-		{
-			Name:   pokemon.FormatEmoji(config.Discord.Emojis.Nundo) + " Nundos",
-			Value:  gathered.NundoValue,
-			Inline: false,
-		},
-		{
-			Name:   pokemon.FormatEmoji(config.Discord.Emojis.Shinies) + " Shinies",
-			Value:  fmt.Sprintf("Species: %d | Total: %s", gathered.ShinySpeciesCount, humanize.Comma(int64(gathered.ShinyCount))),
-			Inline: false,
-		},
-		{
-			Name:   "Gym Statistics",
-			Value:  gathered.GymStats,
-			Inline: false,
-		},
+func humanizeValue(value int) string {
+	return humanize.Comma(int64(value))
+}
+
+func convertToEmoji(level int, config map[string]string) string {
+	replacement, ok := config[strconv.Itoa(level)]
+	if !ok {
+		return fmt.Sprintf("Rocket %d", level)
 	}
+	return replacement
+}
 
-	if gathered.RaidEggStats != "" {
-		newFields := make([]*discordgo.MessageEmbedField, len(fields)+1)
-
-		copy(newFields, fields[:5])
-
-		newFields[5] = &discordgo.MessageEmbedField{
-			Name:   "Active Raids",
-			Value:  gathered.RaidEggStats,
-			Inline: false,
+func GenerateFields(gathered GatheredStats, config config.Config) []*discordgo.MessageEmbedField {
+	currentTemplateFile, err := os.ReadFile("templates/current.override.json")
+	if err != nil {
+		currentTemplateFile, err = os.ReadFile("templates/current.json")
+		if err != nil {
+			panic(err)
 		}
-
-		copy(newFields[6:], fields[5:])
-
-		fields = newFields
 	}
 
-	fields = append(fields, []*discordgo.MessageEmbedField{
-		{
-			Name:   "PokéStops Scanned",
-			Value:  gathered.PokestopStats,
-			Inline: false,
-		},
-		{
-			Name:   "Quest Rewards",
-			Value:  gathered.RewardStats,
-			Inline: false,
-		},
-		{
-			Name:   "Active Lures",
-			Value:  gathered.LureStats,
-			Inline: false,
-		},
-		{
-			Name:   "Active Rockets",
-			Value:  gathered.RocketStats,
-			Inline: false,
-		},
-		{
-			Name:   "Active Kecleon",
-			Value:  gathered.KecleonStats,
-			Inline: false,
-		},
-		{
-			Name:   "Showcases",
-			Value:  gathered.ShowcaseStats,
-			Inline: false,
-		},
-		{
-			Name:   "Routes",
-			Value:  gathered.ActiveRoutesStats,
-			Inline: false,
-		},
-	}...)
+	tmpl, err := template.New("message").Funcs(template.FuncMap{
+		"Humanize":    humanizeValue,
+		"LevelEmoji":  func(level int) string { return convertToEmoji(level, config.LevelEmoji) },
+		"RewardEmoji": func(level int) string { return convertToEmoji(level, config.RewardEmoji) },
+		"LureEmoji":   func(level int) string { return convertToEmoji(level, config.LureEmoji) },
+		"RocketEmoji": func(level int) string { return convertToEmoji(level, config.RocketEmoji) },
+		"EventEmoji":  func(level int) string { return convertToEmoji(level, config.EventEmoji) },
+	}).Parse(string(currentTemplateFile))
+	if err != nil {
+		panic(err)
+	}
+
+	var resultJSON bytes.Buffer
+	if err := tmpl.Execute(&resultJSON, gathered); err != nil {
+		panic(err)
+	}
+
+	var fields []*discordgo.MessageEmbedField
+	if err := json.Unmarshal(resultJSON.Bytes(), &fields); err != nil {
+		panic(err)
+	}
+
 	return fields
 }

--- a/discord/constructor.go
+++ b/discord/constructor.go
@@ -60,6 +60,12 @@ func hasValues(data interface{}) bool {
 				if hasValues(fieldValue.Interface()) {
 					return true
 				}
+			case reflect.Slice:
+				for j := 0; j < fieldValue.Len(); j++ {
+					if hasValues(fieldValue.Index(j).Interface()) {
+						return true
+					}
+				}
 			default:
 				return true
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module Porygon
+module porygon
 
 go 1.21.5
 
@@ -7,6 +7,7 @@ require (
 	github.com/bwmarrin/discordgo v0.27.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/jmoiron/sqlx v1.3.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,17 @@ github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4Ho
 github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
+github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=

--- a/templates/current.json
+++ b/templates/current.json
@@ -33,7 +33,7 @@
     "value": "{{ range .RaidEgg }}{{ LevelEmoji .Level }} Hatched: {{ Humanize .Raid }} | Eggs: {{ Humanize .Egg }}\n{{ end }}"
   },
   {{ end }}
-  {{ if HasValues .Pokestop }}
+  {{ if .Pokestop }}
   {
     "name": "PokéStops Scanned",
     "value": "\uD83D\uDED1 {{ Humanize .Pokestop }}"
@@ -51,15 +51,19 @@
     "value": "{{ range .Lure }}{{ LureEmoji .Type }} {{ Humanize .Count }} {{ end }}"
   },
   {{ end }}
+  {{ if HasValues .Rocket }}
   {
     "name": "Active Rockets",
     "value": "{{ range .Rocket }}{{ RocketEmoji .Type }} {{ Humanize .Count }} {{ end }}"
   },
+  {{ end }}
+  {{ if HasValues .Event }}
   {
     "name": "Event Stops",
     "value": "{{ range .Event }}{{ EventEmoji .Type }} {{ Humanize .Count }} {{ end }}",
     "inline": true
   },
+  {{ end }}
   {
     "name": "Routes",
     "value": "⛳\uFE0F {{ Humanize .Route }}",

--- a/templates/current.json
+++ b/templates/current.json
@@ -27,22 +27,30 @@
     "name": "Gym Statistics",
     "value": "\uD83D\uDD34 {{ Humanize .Gym.Valor }} \uD83D\uDD35 {{ Humanize .Gym.Mystic }} \uD83C\uDF15 {{ Humanize .Gym.Instinct }} ⚪\uFE0F {{ Humanize .Gym.Uncontested }}"
   },
+  {{ if HasValues .RaidEgg }}
   {
     "name": "Active Raids & Eggs",
     "value": "{{ range .RaidEgg }}{{ LevelEmoji .Level }} Hatched: {{ Humanize .Raid }} | Eggs: {{ Humanize .Egg }}\n{{ end }}"
   },
+  {{ end }}
+  {{ if HasValues .Pokestop }}
   {
     "name": "PokéStops Scanned",
     "value": "\uD83D\uDED1 {{ Humanize .Pokestop }}"
   },
+  {{ end }}
+  {{ if HasValues .Reward }}
   {
     "name": "Quest Rewards",
     "value": "{{ range .Reward }}{{ RewardEmoji .Type }} {{ Humanize .Count }} {{ end }}"
   },
+  {{ end }}
+  {{ if HasValues .Lure }}
   {
     "name": "Active Lures",
     "value": "{{ range .Lure }}{{ LureEmoji .Type }} {{ Humanize .Count }} {{ end }}"
   },
+  {{ end }}
   {
     "name": "Active Rockets",
     "value": "{{ range .Rocket }}{{ RocketEmoji .Type }} {{ Humanize .Count }} {{ end }}"

--- a/templates/current.json
+++ b/templates/current.json
@@ -1,0 +1,60 @@
+[
+  {
+    "name": "\uD83D\uDCC8 Scanned",
+    "value": "{{ Humanize .Pokemon.Scanned }}"
+  },
+  {
+    "name": "\uD83D\uDCAF Hundos",
+    {{ if .HundoActiveCount }}
+    "value": "Active: {{ Humanize .HundoActiveCount }} | Total: {{ Humanize .Pokemon.Hundo }}"
+    {{ else }}
+    "value": "{{ Humanize .Pokemon.Hundo }}"
+    {{ end }}
+  },
+  {
+    "name": "\uD83D\uDDD1\uFE0F Nundos",
+    {{ if .NundoActiveCount }}
+    "value": "Active: {{ Humanize .NundoActiveCount }} | Total: {{ Humanize .Pokemon.Nundo }}"
+    {{ else }}
+    "value": "{{ Humanize .Pokemon.Nundo }}"
+    {{ end }}
+  },
+  {
+    "name": "✨ Shinies",
+    "value": "Species: {{ Humanize .Pokemon.ShinySpecies }} | Total: {{ Humanize .Pokemon.Shiny }}"
+  },
+  {
+    "name": "Gym Statistics",
+    "value": "\uD83D\uDD34 {{ Humanize .Gym.Valor }} \uD83D\uDD35 {{ Humanize .Gym.Mystic }} \uD83C\uDF15 {{ Humanize .Gym.Instinct }} ⚪\uFE0F {{ Humanize .Gym.Uncontested }}"
+  },
+  {
+    "name": "Active Raids & Eggs",
+    "value": "{{ range .RaidEgg }}{{ LevelEmoji .Level }} Hatched: {{ Humanize .Raid }} | Eggs: {{ Humanize .Egg }}\n{{ end }}"
+  },
+  {
+    "name": "PokéStops Scanned",
+    "value": "\uD83D\uDED1 {{ Humanize .Pokestop }}"
+  },
+  {
+    "name": "Quest Rewards",
+    "value": "{{ range .Reward }}{{ RewardEmoji .Type }} {{ Humanize .Count }} {{ end }}"
+  },
+  {
+    "name": "Active Lures",
+    "value": "{{ range .Lure }}{{ LureEmoji .Type }} {{ Humanize .Count }} {{ end }}"
+  },
+  {
+    "name": "Active Rockets",
+    "value": "{{ range .Rocket }}{{ RocketEmoji .Type }} {{ Humanize .Count }} {{ end }}"
+  },
+  {
+    "name": "Event Stops",
+    "value": "{{ range .Event }}{{ EventEmoji .Type }} {{ Humanize .Count }} {{ end }}",
+    "inline": true
+  },
+  {
+    "name": "Routes",
+    "value": "⛳\uFE0F {{ Humanize .Route }}",
+    "inline": true
+  }
+]


### PR DESCRIPTION
Hey!

I kinda wanted to reorder things and change locale... so I kinda added template support.

To use the own template, simply create a new one under `templates/current.override.json`. Everything should be straightforward.

Config has mapping for type based emoji only (like raid levels, grunt, lures... etc). All others could be changed within the template itself.

Updated default template + config to look as close as initial.

Might forget to mention something, but basically:
- swapped to sqlx
- added template support
- reworked config
- renamed package (lowercase)
- updated queries
- cleaned code

Could use some cleanup, but sadly I won't have more time for that.

Due to the package name change... it's kind of breaking change, but I couldn't look at this Title case :joy: feel free to rollback this change.

Cheers!